### PR TITLE
fix: artists soundcloud trackUrl not editable

### DIFF
--- a/src/collections/Artists.ts
+++ b/src/collections/Artists.ts
@@ -69,9 +69,9 @@ export const Artists: CollectionConfig = {
         {
           name: 'trackUrl',
           type: 'text',
-          label: 'Track Url',
           virtual: true,
           admin: {
+            readOnly: false,
             description:
               'Paste a SoundCloud track URL to auto-fill the Track ID below.',
           },

--- a/src/collections/Users.ts
+++ b/src/collections/Users.ts
@@ -12,7 +12,6 @@ export const Users: CollectionConfig = {
       type: 'text',
       required: true,
       maxLength: 100,
-      label: 'Username',
     },
   ],
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Made Track URL field editable for Artists in the admin interface.
  * Enhanced user validation: username field is now required with a maximum length of 100 characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mGallee/tohuwabohu/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->